### PR TITLE
feat: criados os endpoints de cadastrar um cliente e listar clientes

### DIFF
--- a/src/controladores/clientes.js
+++ b/src/controladores/clientes.js
@@ -1,0 +1,52 @@
+const knex = require("../conexao");
+
+const cadastrarCliente = async (req, res) => {
+    const { nome, email, cpf, cep, rua, numero, bairro, cidade, estado } = req.body;
+
+    const uf = estado ? estado.toUpperCase() : estado;
+
+    try {
+        const existeEmail = await knex('clientes').where({ email }).first();
+
+        if (existeEmail) {
+            return res.status(400).json({ mensagem: 'Já existe cliente cadastrado com o e-mail informado.' });
+        }
+
+        const existeCpf = await knex('clientes').where({ cpf }).first();
+
+        if (existeCpf) {
+            return res.status(400).json({ mensagem: 'Já existe cliente cadastrado com o cpf informado.' });
+        }
+
+        const novoCliente = await knex('clientes').insert({
+            nome,
+            email,
+            cpf,
+            cep,
+            rua,
+            numero,
+            bairro,
+            cidade,
+            estado: uf
+        }).returning(['id', 'nome', 'email', 'cpf']);
+
+        return res.status(201).json(novoCliente);
+
+    } catch (error) {
+        return res.status(500).json({ mensagem: error.message });
+    }
+}
+
+const listarClientes = async (req, res) => {
+    try {
+        const clientes = await knex('clientes');
+        return res.json(clientes);
+    } catch (error) {
+        return res.status(500).json({ mensagem: error.message })
+    }
+}
+
+module.exports = {
+    cadastrarCliente,
+    listarClientes
+}

--- a/src/rotas.js
+++ b/src/rotas.js
@@ -4,8 +4,10 @@ const usuarios = require('./controladores/usuarios');
 const { login } = require('./controladores/login');
 const { listarCategorias } = require('./controladores/categorias');
 const validarRequisicao = require('./intermediarios/validarRequisicao');
+const clientes = require('./controladores/clientes');
 const schemaUsuario = require('./validacoes/schemaUsuario');
 const schemaLogin = require('./validacoes/schemaLogin');
+const schemaCliente = require('./validacoes/schemaCliente');
 
 const rotas = express();
 
@@ -18,5 +20,8 @@ rotas.use(verificaToken);
 
 rotas.get('/usuario', usuarios.detalharUsuario);
 rotas.put('/usuario', validarRequisicao(schemaUsuario), usuarios.editarUsuario);
+
+rotas.get('/cliente', clientes.listarClientes);
+rotas.post('/cliente', validarRequisicao(schemaCliente), clientes.cadastrarCliente);
 
 module.exports = rotas;

--- a/src/validacoes/schemaCliente.js
+++ b/src/validacoes/schemaCliente.js
@@ -1,0 +1,54 @@
+const joi = require('joi');
+
+const schemaCliente = joi.object({
+    nome: joi.string().required().messages({
+        'any.required': 'O campo nome é obrigatório.',
+        'string.empty': 'O campo nome é obrigatório.',
+        'string.base': 'O campo nome deve possuir um formato válido.'
+    }),
+
+    email: joi.string().required().email().messages({
+        'any.required': 'O campo email é obrigatório.',
+        'string.empty': 'O campo email é obrigatório.',
+        'string.base': 'O campo email deve possuir um formato válido.',
+        'string.email': 'O campo email deve possuir um formato válido.'
+    }),
+
+    cpf: joi.string().required().min(11).max(11).messages({
+        'any.required': 'O campo cpf é obrigatório.',
+        'string.empty': 'O campo cpf é obrigatório.',
+        'string.base': 'O campo cpf deve possuir um formato válido.',
+        'string.min': 'O campo cpf deve ter no mínimo 11 caracteres',
+        'string.max': 'O campo cpf não aceita caracteres especiais.'
+    }),
+
+    cep: joi.string().min(8).max(9).messages({
+        'string.base': 'O campo cep deve possuir um formato válido.',
+        'string.min': 'O campo cep deve ter no mínimo 8 caracteres.',
+        'string.max': 'O campo cep dever ter no máximo 9 caracteres.'
+    }),
+
+    rua: joi.string().messages({
+        'string.base': 'O campo rua deve possuir um formato válido.'
+    }),
+
+    numero: joi.string().messages({
+        'string.base': 'O campo rua deve ser do tipo texto.'
+    }),
+
+    bairro: joi.string().messages({
+        'string.base': 'O campo bairro deve possuir um formato válido.'
+    }),
+
+    cidade: joi.string().messages({
+        'string.base': 'O campo cidade deve possuir um formato válido.'
+    }),
+
+    estado: joi.string().min(2).max(2).messages({
+        'string.base': 'O campo estado deve possuir um formato válido.',
+        'string.min': 'O campo estado deve ser a sigla do estado.',
+        'string.max': 'O campo estado deve ser a sigla do estado.'
+    }),
+})
+
+module.exports = schemaCliente;


### PR DESCRIPTION
Realizei a implementação das funcionalidades de listagem e cadastro de cliente. Fiquei com um pouco de dúvida para decidir como padronizar a entrada dos dados de CPF, então usei uma validação para aceitar apenas os números do documento. Quanto ao retorno, ao cadastrar deixei retornando os campos obrigatórios apenas, mas estou cogitando retornar todas as informações de endereço também.